### PR TITLE
Convert multipart/form-data requests to HttpMultipartRequest

### DIFF
--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -602,6 +602,7 @@ schemas: !<!Schemas>
         xml:
           name: Start
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -615,6 +616,7 @@ schemas: !<!Schemas>
         xml:
           name: End
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -975,6 +977,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1954,6 +1957,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1968,6 +1972,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2153,6 +2158,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2221,6 +2227,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2235,6 +2242,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4839,6 +4847,7 @@ schemas: !<!Schemas>
         xml:
           name: Committed
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4854,6 +4863,7 @@ schemas: !<!Schemas>
         xml:
           name: Uncommitted
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4869,6 +4879,7 @@ schemas: !<!Schemas>
         xml:
           name: Latest
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -9546,6 +9557,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -9897,6 +9909,7 @@ schemas: !<!Schemas>
                 xml:
                   name: Container
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -9912,6 +9925,7 @@ schemas: !<!Schemas>
               xml:
                 name: Containers
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -9938,6 +9952,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10135,6 +10150,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10535,6 +10551,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Properties
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -10577,6 +10594,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Metadata
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -10599,6 +10617,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -10626,6 +10645,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -10657,6 +10677,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10805,6 +10826,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -10836,6 +10858,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10969,6 +10992,7 @@ schemas: !<!Schemas>
         xml:
           name: BlockList
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -11029,6 +11053,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -11051,6 +11076,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -11114,6 +11140,7 @@ schemas: !<!Schemas>
                 xml:
                   name: PageRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -11170,6 +11197,7 @@ schemas: !<!Schemas>
                 xml:
                   name: ClearRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -11217,6 +11245,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -602,6 +602,7 @@ schemas: !<!Schemas>
         xml:
           name: Start
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -615,6 +616,7 @@ schemas: !<!Schemas>
         xml:
           name: End
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -975,6 +977,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1954,6 +1957,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1968,6 +1972,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2153,6 +2158,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2221,6 +2227,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2235,6 +2242,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4839,6 +4847,7 @@ schemas: !<!Schemas>
         xml:
           name: Committed
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4854,6 +4863,7 @@ schemas: !<!Schemas>
         xml:
           name: Uncommitted
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4869,6 +4879,7 @@ schemas: !<!Schemas>
         xml:
           name: Latest
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -14486,6 +14497,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -14837,6 +14849,7 @@ schemas: !<!Schemas>
                 xml:
                   name: Container
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -14852,6 +14865,7 @@ schemas: !<!Schemas>
               xml:
                 name: Containers
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -14878,6 +14892,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15075,6 +15090,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15475,6 +15491,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Properties
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -15517,6 +15534,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Metadata
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -15539,6 +15557,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -15566,6 +15585,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -15597,6 +15617,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15745,6 +15766,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -15776,6 +15798,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15909,6 +15932,7 @@ schemas: !<!Schemas>
         xml:
           name: BlockList
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15969,6 +15993,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -15991,6 +16016,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -16054,6 +16080,7 @@ schemas: !<!Schemas>
                 xml:
                   name: PageRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -16110,6 +16137,7 @@ schemas: !<!Schemas>
                 xml:
                   name: ClearRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -16157,6 +16185,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -602,6 +602,7 @@ schemas: !<!Schemas>
         xml:
           name: Start
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -615,6 +616,7 @@ schemas: !<!Schemas>
         xml:
           name: End
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -975,6 +977,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1954,6 +1957,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1968,6 +1972,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2153,6 +2158,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2221,6 +2227,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2235,6 +2242,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4839,6 +4847,7 @@ schemas: !<!Schemas>
         xml:
           name: Committed
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4854,6 +4863,7 @@ schemas: !<!Schemas>
         xml:
           name: Uncommitted
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4869,6 +4879,7 @@ schemas: !<!Schemas>
         xml:
           name: Latest
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -9546,6 +9557,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -9897,6 +9909,7 @@ schemas: !<!Schemas>
                 xml:
                   name: Container
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -9912,6 +9925,7 @@ schemas: !<!Schemas>
               xml:
                 name: Containers
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -9938,6 +9952,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10135,6 +10150,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10535,6 +10551,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Properties
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -10577,6 +10594,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Metadata
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -10599,6 +10617,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -10626,6 +10645,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -10657,6 +10677,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10805,6 +10826,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -10836,6 +10858,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -10969,6 +10992,7 @@ schemas: !<!Schemas>
         xml:
           name: BlockList
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -11029,6 +11053,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -11051,6 +11076,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -11114,6 +11140,7 @@ schemas: !<!Schemas>
                 xml:
                   name: PageRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -11170,6 +11197,7 @@ schemas: !<!Schemas>
                 xml:
                   name: ClearRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -11217,6 +11245,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -602,6 +602,7 @@ schemas: !<!Schemas>
         xml:
           name: Start
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -615,6 +616,7 @@ schemas: !<!Schemas>
         xml:
           name: End
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -975,6 +977,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1954,6 +1957,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1968,6 +1972,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2153,6 +2158,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2221,6 +2227,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2235,6 +2242,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4839,6 +4847,7 @@ schemas: !<!Schemas>
         xml:
           name: Committed
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4854,6 +4863,7 @@ schemas: !<!Schemas>
         xml:
           name: Uncommitted
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -4869,6 +4879,7 @@ schemas: !<!Schemas>
         xml:
           name: Latest
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -14486,6 +14497,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -14837,6 +14849,7 @@ schemas: !<!Schemas>
                 xml:
                   name: Container
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -14852,6 +14865,7 @@ schemas: !<!Schemas>
               xml:
                 name: Containers
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -14878,6 +14892,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15075,6 +15090,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15475,6 +15491,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Properties
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -15517,6 +15534,7 @@ schemas: !<!Schemas>
                             xml:
                               name: Metadata
                               attribute: false
+                              text: false
                               wrapped: false
                           serializationFormats:
                             - xml
@@ -15539,6 +15557,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -15566,6 +15585,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -15597,6 +15617,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15745,6 +15766,7 @@ schemas: !<!Schemas>
               xml:
                 name: Blobs
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -15776,6 +15798,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15909,6 +15932,7 @@ schemas: !<!Schemas>
         xml:
           name: BlockList
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -15969,6 +15993,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -15991,6 +16016,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -16054,6 +16080,7 @@ schemas: !<!Schemas>
                 xml:
                   name: PageRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -16110,6 +16137,7 @@ schemas: !<!Schemas>
                 xml:
                   name: ClearRange
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -16157,6 +16185,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/body-formdata-urlencoded/flattened.yaml
+++ b/modelerfour/test/scenarios/body-formdata-urlencoded/flattened.yaml
@@ -1,0 +1,208 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata-urlencoded
+schemas: !<!Schemas> 
+  strings:
+    - !<!StringSchema> &ref_2
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_4
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_0
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-name
+          description: Updated name of the pet
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-status
+          description: Updated status of the pet
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_5
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> &ref_7
+          schema: *ref_0
+          serializedName: name
+          language: !<!Languages> 
+            default:
+              name: name
+              description: Updated name of the pet
+          protocol: !<!Protocols> {}
+        - !<!Property> &ref_8
+          schema: *ref_1
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: Updated status of the pet
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - form
+      usage:
+        - input
+      language: !<!Languages> 
+        default:
+          name: paths·gci8ri·get·requestbody·content·application-x_www_form_urlencoded·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_3
+    schema: *ref_2
+    clientDefaultValue: ''
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: ''
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_3
+          - !<!Parameter> &ref_11
+            schema: *ref_4
+            implementation: Method
+            required: true
+            language: !<!Languages> 
+              default:
+                name: petId
+                description: ID of pet that needs to be updated
+                serializedName: petId
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: path
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_5
+                flattened: true
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: ''
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: form
+              - !<!VirtualParameter> &ref_9
+                schema: *ref_0
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_7
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Updated name of the pet
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_10
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_8
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: Updated status of the pet
+                protocol: !<!Protocols> {}
+            signatureParameters:
+              - *ref_9
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /
+                method: get
+                knownMediaType: form
+                mediaTypes:
+                  - application/x-www-form-urlencoded
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_11
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '405'
+        language: !<!Languages> 
+          default:
+            name: updatePetWithForm
+            description: Updates a pet in the store with form data
+            summary: Updates a pet in the store with form data
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata-urlencoded/grouped.yaml
+++ b/modelerfour/test/scenarios/body-formdata-urlencoded/grouped.yaml
@@ -1,0 +1,208 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata-urlencoded
+schemas: !<!Schemas> 
+  strings:
+    - !<!StringSchema> &ref_2
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_4
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_0
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-name
+          description: Updated name of the pet
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-status
+          description: Updated status of the pet
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_5
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> &ref_7
+          schema: *ref_0
+          serializedName: name
+          language: !<!Languages> 
+            default:
+              name: name
+              description: Updated name of the pet
+          protocol: !<!Protocols> {}
+        - !<!Property> &ref_8
+          schema: *ref_1
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: Updated status of the pet
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - form
+      usage:
+        - input
+      language: !<!Languages> 
+        default:
+          name: paths·gci8ri·get·requestbody·content·application-x_www_form_urlencoded·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_3
+    schema: *ref_2
+    clientDefaultValue: ''
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: ''
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_3
+          - !<!Parameter> &ref_11
+            schema: *ref_4
+            implementation: Method
+            required: true
+            language: !<!Languages> 
+              default:
+                name: petId
+                description: ID of pet that needs to be updated
+                serializedName: petId
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: path
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_5
+                flattened: true
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: ''
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: form
+              - !<!VirtualParameter> &ref_9
+                schema: *ref_0
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_7
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Updated name of the pet
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_10
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_8
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: Updated status of the pet
+                protocol: !<!Protocols> {}
+            signatureParameters:
+              - *ref_9
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /
+                method: get
+                knownMediaType: form
+                mediaTypes:
+                  - application/x-www-form-urlencoded
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_11
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '405'
+        language: !<!Languages> 
+          default:
+            name: updatePetWithForm
+            description: Updates a pet in the store with form data
+            summary: Updates a pet in the store with form data
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata-urlencoded/modeler.yaml
+++ b/modelerfour/test/scenarios/body-formdata-urlencoded/modeler.yaml
@@ -1,0 +1,184 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata-urlencoded
+schemas: !<!Schemas> 
+  strings:
+    - !<!StringSchema> &ref_2
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: string
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_0
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-name
+          description: Updated name of the pet
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: get-content-schema-status
+          description: Updated status of the pet
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_5
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_0
+          serializedName: name
+          language: !<!Languages> 
+            default:
+              name: name
+              description: Updated name of the pet
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_1
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: Updated status of the pet
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - form
+      usage:
+        - input
+      language: !<!Languages> 
+        default:
+          name: paths·gci8ri·get·requestbody·content·application-x_www_form_urlencoded·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_7
+    schema: *ref_2
+    clientDefaultValue: ''
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: ''
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_7
+          - !<!Parameter> &ref_4
+            schema: *ref_3
+            implementation: Method
+            required: true
+            language: !<!Languages> 
+              default:
+                name: petId
+                description: ID of pet that needs to be updated
+                serializedName: petId
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: path
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_5
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: ''
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: form
+            signatureParameters:
+              - *ref_6
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /
+                method: get
+                knownMediaType: form
+                mediaTypes:
+                  - application/x-www-form-urlencoded
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_4
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '405'
+        language: !<!Languages> 
+          default:
+            name: updatePetWithForm
+            description: Updates a pet in the store with form data
+            summary: Updates a pet in the store with form data
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata-urlencoded/namer.yaml
+++ b/modelerfour/test/scenarios/body-formdata-urlencoded/namer.yaml
@@ -1,0 +1,208 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata-urlencoded
+schemas: !<!Schemas> 
+  strings:
+    - !<!StringSchema> &ref_2
+      type: string
+      language: !<!Languages> 
+        default:
+          name: String
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_4
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: String
+          description: ''
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_0
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: GetContentSchemaName
+          description: Updated name of the pet
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: GetContentSchemaStatus
+          description: Updated status of the pet
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_5
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> &ref_7
+          schema: *ref_0
+          serializedName: name
+          language: !<!Languages> 
+            default:
+              name: name
+              description: Updated name of the pet
+          protocol: !<!Protocols> {}
+        - !<!Property> &ref_8
+          schema: *ref_1
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: Updated status of the pet
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - form
+      usage:
+        - input
+      language: !<!Languages> 
+        default:
+          name: PathsGci8RiGetRequestbodyContentApplicationXWwwFormUrlencodedSchema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_3
+    schema: *ref_2
+    clientDefaultValue: ''
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: ''
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_3
+          - !<!Parameter> &ref_11
+            schema: *ref_4
+            implementation: Method
+            required: true
+            language: !<!Languages> 
+              default:
+                name: petId
+                description: ID of pet that needs to be updated
+                serializedName: petId
+            protocol: !<!Protocols> 
+              http: !<!HttpParameter> 
+                in: path
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_5
+                flattened: true
+                implementation: Method
+                required: false
+                language: !<!Languages> 
+                  default:
+                    name: _status
+                    description: ''
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: form
+              - !<!VirtualParameter> &ref_9
+                schema: *ref_0
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_7
+                language: !<!Languages> 
+                  default:
+                    name: name
+                    description: Updated name of the pet
+                protocol: !<!Protocols> {}
+              - !<!VirtualParameter> &ref_10
+                schema: *ref_1
+                implementation: Method
+                originalParameter: *ref_6
+                pathToProperty: []
+                targetProperty: *ref_8
+                language: !<!Languages> 
+                  default:
+                    name: status
+                    description: Updated status of the pet
+                protocol: !<!Protocols> {}
+            signatureParameters:
+              - *ref_9
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpWithBodyRequest> 
+                path: /
+                method: get
+                knownMediaType: form
+                mediaTypes:
+                  - application/x-www-form-urlencoded
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_11
+        responses:
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '200'
+          - !<!Response> 
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                statusCodes:
+                  - '405'
+        language: !<!Languages> 
+          default:
+            name: UpdatePetWithForm
+            description: Updates a pet in the store with form data
+            summary: Updates a pet in the store with form data
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: ''
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: BodyFormdataUrlencoded
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata/flattened.yaml
+++ b/modelerfour/test/scenarios/body-formdata/flattened.yaml
@@ -1,0 +1,315 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata
+schemas: !<!Schemas> 
+  numbers:
+    - !<!NumberSchema> &ref_0
+      type: integer
+      precision: 32
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+      protocol: !<!Protocols> {}
+  strings:
+    - !<!StringSchema> &ref_4
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: post-content-schema-fileName
+          description: File name to upload. Name has to be spelled exactly as written here.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: Error-message
+          description: ''
+      protocol: !<!Protocols> {}
+  binaries:
+    - !<!BinarySchema> &ref_2
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: File to upload.
+      protocol: !<!Protocols> {}
+    - !<!BinarySchema> &ref_9
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: ''
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_8
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_0
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_1
+          serializedName: message
+          language: !<!Languages> 
+            default:
+              name: message
+              description: ''
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - json
+      usage:
+        - exception
+      language: !<!Languages> 
+        default:
+          name: Error
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+    - !<!ObjectSchema> 
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_2
+          required: true
+          serializedName: fileContent
+          language: !<!Languages> 
+            default:
+              name: fileContent
+              description: File to upload.
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_3
+          required: true
+          serializedName: fileName
+          language: !<!Languages> 
+            default:
+              name: fileName
+              description: File name to upload. Name has to be spelled exactly as written here.
+          protocol: !<!Protocols> {}
+      language: !<!Languages> 
+        default:
+          name: paths·1mqqetp·formdata-stream-uploadfile·post·requestbody·content·multipart-form_data·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_5
+    schema: *ref_4
+    clientDefaultValue: 'http://localhost:3000'
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: formdata
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_2
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                    serializedName: fileContent
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+              - !<!Parameter> &ref_7
+                schema: *ref_3
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileName
+                    description: File name to upload. Name has to be spelled exactly as written here.
+                    serializedName: fileName
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+            signatureParameters:
+              - *ref_6
+              - *ref_7
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpMultipartRequest> 
+                path: /formdata/stream/uploadfile
+                method: post
+                knownMediaType: multipart
+                mediaTypes:
+                  - multipart/form-data
+                multipart: true
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFile
+            description: Upload file
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_10
+                schema: *ref_9
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: binary
+            signatureParameters:
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryRequest> 
+                path: /formdata/stream/uploadfile
+                method: put
+                binary: true
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFileViaBody
+            description: Upload file
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: formdata
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata/grouped.yaml
+++ b/modelerfour/test/scenarios/body-formdata/grouped.yaml
@@ -1,0 +1,315 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata
+schemas: !<!Schemas> 
+  numbers:
+    - !<!NumberSchema> &ref_0
+      type: integer
+      precision: 32
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+      protocol: !<!Protocols> {}
+  strings:
+    - !<!StringSchema> &ref_4
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: post-content-schema-fileName
+          description: File name to upload. Name has to be spelled exactly as written here.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: Error-message
+          description: ''
+      protocol: !<!Protocols> {}
+  binaries:
+    - !<!BinarySchema> &ref_2
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: File to upload.
+      protocol: !<!Protocols> {}
+    - !<!BinarySchema> &ref_9
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: ''
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_8
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_0
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_1
+          serializedName: message
+          language: !<!Languages> 
+            default:
+              name: message
+              description: ''
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - json
+      usage:
+        - exception
+      language: !<!Languages> 
+        default:
+          name: Error
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+    - !<!ObjectSchema> 
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_2
+          required: true
+          serializedName: fileContent
+          language: !<!Languages> 
+            default:
+              name: fileContent
+              description: File to upload.
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_3
+          required: true
+          serializedName: fileName
+          language: !<!Languages> 
+            default:
+              name: fileName
+              description: File name to upload. Name has to be spelled exactly as written here.
+          protocol: !<!Protocols> {}
+      language: !<!Languages> 
+        default:
+          name: paths·1mqqetp·formdata-stream-uploadfile·post·requestbody·content·multipart-form_data·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_5
+    schema: *ref_4
+    clientDefaultValue: 'http://localhost:3000'
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: formdata
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_2
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                    serializedName: fileContent
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+              - !<!Parameter> &ref_7
+                schema: *ref_3
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileName
+                    description: File name to upload. Name has to be spelled exactly as written here.
+                    serializedName: fileName
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+            signatureParameters:
+              - *ref_6
+              - *ref_7
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpMultipartRequest> 
+                path: /formdata/stream/uploadfile
+                method: post
+                knownMediaType: multipart
+                mediaTypes:
+                  - multipart/form-data
+                multipart: true
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFile
+            description: Upload file
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_10
+                schema: *ref_9
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: binary
+            signatureParameters:
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryRequest> 
+                path: /formdata/stream/uploadfile
+                method: put
+                binary: true
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFileViaBody
+            description: Upload file
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: formdata
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata/modeler.yaml
+++ b/modelerfour/test/scenarios/body-formdata/modeler.yaml
@@ -1,0 +1,315 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata
+schemas: !<!Schemas> 
+  numbers:
+    - !<!NumberSchema> &ref_3
+      type: integer
+      precision: 32
+      language: !<!Languages> 
+        default:
+          name: integer
+          description: ''
+      protocol: !<!Protocols> {}
+  strings:
+    - !<!StringSchema> &ref_4
+      type: string
+      language: !<!Languages> 
+        default:
+          name: string
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_2
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: post-content-schema-fileName
+          description: File name to upload. Name has to be spelled exactly as written here.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_0
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: Error-message
+          description: ''
+      protocol: !<!Protocols> {}
+  binaries:
+    - !<!BinarySchema> &ref_1
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: File to upload.
+      protocol: !<!Protocols> {}
+    - !<!BinarySchema> &ref_9
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: ''
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_7
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_3
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_0
+          serializedName: message
+          language: !<!Languages> 
+            default:
+              name: message
+              description: ''
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - json
+      usage:
+        - exception
+      language: !<!Languages> 
+        default:
+          name: Error
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+    - !<!ObjectSchema> 
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_1
+          required: true
+          serializedName: fileContent
+          language: !<!Languages> 
+            default:
+              name: fileContent
+              description: File to upload.
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_2
+          required: true
+          serializedName: fileName
+          language: !<!Languages> 
+            default:
+              name: fileName
+              description: File name to upload. Name has to be spelled exactly as written here.
+          protocol: !<!Protocols> {}
+      language: !<!Languages> 
+        default:
+          name: paths·1mqqetp·formdata-stream-uploadfile·post·requestbody·content·multipart-form_data·schema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_8
+    schema: *ref_4
+    clientDefaultValue: 'http://localhost:3000'
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: formdata
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_8
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_5
+                schema: *ref_1
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                    serializedName: fileContent
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+              - !<!Parameter> &ref_6
+                schema: *ref_2
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileName
+                    description: File name to upload. Name has to be spelled exactly as written here.
+                    serializedName: fileName
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+            signatureParameters:
+              - *ref_5
+              - *ref_6
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpMultipartRequest> 
+                path: /formdata/stream/uploadfile
+                method: post
+                knownMediaType: multipart
+                mediaTypes:
+                  - multipart/form-data
+                multipart: true
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_7
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFile
+            description: Upload file
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_8
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_10
+                schema: *ref_9
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: binary
+            signatureParameters:
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryRequest> 
+                path: /formdata/stream/uploadfile
+                method: put
+                binary: true
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_7
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFileViaBody
+            description: Upload file
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: formdata
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: ''
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/body-formdata/namer.yaml
+++ b/modelerfour/test/scenarios/body-formdata/namer.yaml
@@ -1,0 +1,315 @@
+!<!CodeModel> 
+info: !<!Info> 
+  description: Test Infrastructure for AutoRest Swagger BAT
+  title: body-formdata
+schemas: !<!Schemas> 
+  numbers:
+    - !<!NumberSchema> &ref_0
+      type: integer
+      precision: 32
+      language: !<!Languages> 
+        default:
+          name: Integer
+          description: ''
+      protocol: !<!Protocols> {}
+  strings:
+    - !<!StringSchema> &ref_4
+      type: string
+      language: !<!Languages> 
+        default:
+          name: String
+          description: simple string
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_3
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: PostContentSchemaFileName
+          description: File name to upload. Name has to be spelled exactly as written here.
+      protocol: !<!Protocols> {}
+    - !<!StringSchema> &ref_1
+      type: string
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: ErrorMessage
+          description: ''
+      protocol: !<!Protocols> {}
+  binaries:
+    - !<!BinarySchema> &ref_2
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: File to upload.
+      protocol: !<!Protocols> {}
+    - !<!BinarySchema> &ref_9
+      type: binary
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      language: !<!Languages> 
+        default:
+          name: binary
+          description: ''
+      protocol: !<!Protocols> {}
+  objects:
+    - !<!ObjectSchema> &ref_8
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_0
+          serializedName: status
+          language: !<!Languages> 
+            default:
+              name: status
+              description: ''
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_1
+          serializedName: message
+          language: !<!Languages> 
+            default:
+              name: message
+              description: ''
+          protocol: !<!Protocols> {}
+      serializationFormats:
+        - json
+      usage:
+        - exception
+      language: !<!Languages> 
+        default:
+          name: Error
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+    - !<!ObjectSchema> 
+      type: object
+      apiVersions:
+        - !<!ApiVersion> 
+          version: 1.0.0
+      properties:
+        - !<!Property> 
+          schema: *ref_2
+          required: true
+          serializedName: fileContent
+          language: !<!Languages> 
+            default:
+              name: fileContent
+              description: File to upload.
+          protocol: !<!Protocols> {}
+        - !<!Property> 
+          schema: *ref_3
+          required: true
+          serializedName: fileName
+          language: !<!Languages> 
+            default:
+              name: fileName
+              description: File name to upload. Name has to be spelled exactly as written here.
+          protocol: !<!Protocols> {}
+      language: !<!Languages> 
+        default:
+          name: Paths1MqqetpFormdataStreamUploadfilePostRequestbodyContentMultipartFormDataSchema
+          description: ''
+          namespace: ''
+      protocol: !<!Protocols> {}
+globalParameters:
+  - !<!Parameter> &ref_5
+    schema: *ref_4
+    clientDefaultValue: 'http://localhost:3000'
+    implementation: Client
+    origin: 'modelerfour:synthesized/host'
+    required: true
+    extensions:
+      x-ms-skip-url-encoding: true
+    language: !<!Languages> 
+      default:
+        name: $host
+        description: server parameter
+        serializedName: $host
+    protocol: !<!Protocols> 
+      http: !<!HttpParameter> 
+        in: uri
+operationGroups:
+  - !<!OperationGroup> 
+    $key: formdata
+    operations:
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_6
+                schema: *ref_2
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                    serializedName: fileContent
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+              - !<!Parameter> &ref_7
+                schema: *ref_3
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileName
+                    description: File name to upload. Name has to be spelled exactly as written here.
+                    serializedName: fileName
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+            signatureParameters:
+              - *ref_6
+              - *ref_7
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpMultipartRequest> 
+                path: /formdata/stream/uploadfile
+                method: post
+                knownMediaType: multipart
+                mediaTypes:
+                  - multipart/form-data
+                multipart: true
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFile
+            description: Upload file
+        protocol: !<!Protocols> {}
+      - !<!Operation> 
+        apiVersions:
+          - !<!ApiVersion> 
+            version: 1.0.0
+        parameters:
+          - *ref_5
+        requests:
+          - !<!Request> 
+            parameters:
+              - !<!Parameter> &ref_10
+                schema: *ref_9
+                implementation: Method
+                required: true
+                language: !<!Languages> 
+                  default:
+                    name: fileContent
+                    description: File to upload.
+                protocol: !<!Protocols> 
+                  http: !<!HttpParameter> 
+                    in: body
+                    style: binary
+            signatureParameters:
+              - *ref_10
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryRequest> 
+                path: /formdata/stream/uploadfile
+                method: put
+                binary: true
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !<!BinaryResponse> 
+            binary: true
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpBinaryResponse> 
+                knownMediaType: binary
+                mediaTypes:
+                  - application/octet-stream
+                  - application/json
+                statusCodes:
+                  - '200'
+        exceptions:
+          - !<!SchemaResponse> 
+            schema: *ref_8
+            language: !<!Languages> 
+              default:
+                name: ''
+                description: ''
+            protocol: !<!Protocols> 
+              http: !<!HttpResponse> 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        language: !<!Languages> 
+          default:
+            name: UploadFileViaBody
+            description: Upload file
+        protocol: !<!Protocols> {}
+    language: !<!Languages> 
+      default:
+        name: Formdata
+        description: ''
+    protocol: !<!Protocols> {}
+security: !<!Security> 
+  authenticationRequired: false
+language: !<!Languages> 
+  default:
+    name: BodyFormdata
+    description: ''
+protocol: !<!Protocols> 
+  http: !<!HttpModel> {}

--- a/modelerfour/test/scenarios/xml-service/flattened.yaml
+++ b/modelerfour/test/scenarios/xml-service/flattened.yaml
@@ -152,6 +152,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -166,6 +167,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -180,6 +182,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -194,6 +197,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -219,6 +223,7 @@ schemas: !<!Schemas>
         xml:
           name: item
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -244,6 +249,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -259,6 +265,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -285,6 +292,7 @@ schemas: !<!Schemas>
         xml:
           name: name
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -300,6 +308,7 @@ schemas: !<!Schemas>
         xml:
           name: flavor
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -314,6 +323,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -470,6 +480,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -484,6 +495,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1029,6 +1041,7 @@ schemas: !<!Schemas>
         xml:
           name: expiration
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1185,6 +1198,7 @@ schemas: !<!Schemas>
               xml:
                 name: XMLComplexTypeWithMeta
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -1303,6 +1317,7 @@ schemas: !<!Schemas>
                 xml:
                   name: slide
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1330,6 +1345,7 @@ schemas: !<!Schemas>
         xml:
           name: slideshow
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1391,6 +1407,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1413,6 +1430,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1470,6 +1488,7 @@ schemas: !<!Schemas>
         xml:
           name: banana
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1645,6 +1664,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1671,6 +1691,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1924,6 +1945,7 @@ schemas: !<!Schemas>
                 xml:
                   name: CorsRule
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1941,6 +1963,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -2055,6 +2078,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2505,6 +2529,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -2557,6 +2582,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2635,6 +2661,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2651,6 +2678,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:
@@ -2669,6 +2697,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/xml-service/grouped.yaml
+++ b/modelerfour/test/scenarios/xml-service/grouped.yaml
@@ -152,6 +152,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -166,6 +167,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -180,6 +182,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -194,6 +197,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -219,6 +223,7 @@ schemas: !<!Schemas>
         xml:
           name: item
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -244,6 +249,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -259,6 +265,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -285,6 +292,7 @@ schemas: !<!Schemas>
         xml:
           name: name
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -300,6 +308,7 @@ schemas: !<!Schemas>
         xml:
           name: flavor
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -314,6 +323,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -470,6 +480,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -484,6 +495,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1029,6 +1041,7 @@ schemas: !<!Schemas>
         xml:
           name: expiration
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1185,6 +1198,7 @@ schemas: !<!Schemas>
               xml:
                 name: XMLComplexTypeWithMeta
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -1303,6 +1317,7 @@ schemas: !<!Schemas>
                 xml:
                   name: slide
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1330,6 +1345,7 @@ schemas: !<!Schemas>
         xml:
           name: slideshow
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1391,6 +1407,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1413,6 +1430,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1470,6 +1488,7 @@ schemas: !<!Schemas>
         xml:
           name: banana
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1645,6 +1664,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1671,6 +1691,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1924,6 +1945,7 @@ schemas: !<!Schemas>
                 xml:
                   name: CorsRule
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1941,6 +1963,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -2055,6 +2078,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2505,6 +2529,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -2557,6 +2582,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2635,6 +2661,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2651,6 +2678,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:
@@ -2669,6 +2697,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/xml-service/modeler.yaml
+++ b/modelerfour/test/scenarios/xml-service/modeler.yaml
@@ -152,6 +152,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -166,6 +167,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -180,6 +182,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -194,6 +197,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -219,6 +223,7 @@ schemas: !<!Schemas>
         xml:
           name: item
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -244,6 +249,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -259,6 +265,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -285,6 +292,7 @@ schemas: !<!Schemas>
         xml:
           name: name
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -300,6 +308,7 @@ schemas: !<!Schemas>
         xml:
           name: flavor
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -314,6 +323,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -470,6 +480,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -484,6 +495,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1029,6 +1041,7 @@ schemas: !<!Schemas>
         xml:
           name: expiration
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1185,6 +1198,7 @@ schemas: !<!Schemas>
               xml:
                 name: XMLComplexTypeWithMeta
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -1303,6 +1317,7 @@ schemas: !<!Schemas>
                 xml:
                   name: slide
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1330,6 +1345,7 @@ schemas: !<!Schemas>
         xml:
           name: slideshow
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1391,6 +1407,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1413,6 +1430,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1470,6 +1488,7 @@ schemas: !<!Schemas>
         xml:
           name: banana
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1645,6 +1664,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1671,6 +1691,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1924,6 +1945,7 @@ schemas: !<!Schemas>
                 xml:
                   name: CorsRule
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1941,6 +1963,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -2055,6 +2078,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2505,6 +2529,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -2557,6 +2582,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2635,6 +2661,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2651,6 +2678,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:
@@ -2669,6 +2697,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/scenarios/xml-service/namer.yaml
+++ b/modelerfour/test/scenarios/xml-service/namer.yaml
@@ -152,6 +152,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -166,6 +167,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -180,6 +182,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -194,6 +197,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -219,6 +223,7 @@ schemas: !<!Schemas>
         xml:
           name: item
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -244,6 +249,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -259,6 +265,7 @@ schemas: !<!Schemas>
         xml:
           name: Apple
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -285,6 +292,7 @@ schemas: !<!Schemas>
         xml:
           name: name
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -300,6 +308,7 @@ schemas: !<!Schemas>
         xml:
           name: flavor
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -314,6 +323,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -470,6 +480,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -484,6 +495,7 @@ schemas: !<!Schemas>
       serialization:
         xml:
           attribute: true
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1029,6 +1041,7 @@ schemas: !<!Schemas>
         xml:
           name: expiration
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -1185,6 +1198,7 @@ schemas: !<!Schemas>
               xml:
                 name: XMLComplexTypeWithMeta
                 attribute: false
+                text: false
                 wrapped: false
             serializationFormats:
               - xml
@@ -1303,6 +1317,7 @@ schemas: !<!Schemas>
                 xml:
                   name: slide
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1330,6 +1345,7 @@ schemas: !<!Schemas>
         xml:
           name: slideshow
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1391,6 +1407,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1413,6 +1430,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1470,6 +1488,7 @@ schemas: !<!Schemas>
         xml:
           name: banana
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1645,6 +1664,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -1671,6 +1691,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -1924,6 +1945,7 @@ schemas: !<!Schemas>
                 xml:
                   name: CorsRule
                   attribute: false
+                  text: false
                   wrapped: false
               serializationFormats:
                 - xml
@@ -1941,6 +1963,7 @@ schemas: !<!Schemas>
             serialization:
               xml:
                 attribute: false
+                text: false
                 wrapped: true
             language: !<!Languages> 
               default:
@@ -2055,6 +2078,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifier
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2505,6 +2529,7 @@ schemas: !<!Schemas>
                       xml:
                         name: Blob
                         attribute: false
+                        text: false
                         wrapped: false
                     serializationFormats:
                       - xml
@@ -2557,6 +2582,7 @@ schemas: !<!Schemas>
         xml:
           name: EnumerationResults
           attribute: false
+          text: false
           wrapped: false
       serializationFormats:
         - xml
@@ -2635,6 +2661,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: false
       language: !<!Languages> 
         default:
@@ -2651,6 +2678,7 @@ schemas: !<!Schemas>
         xml:
           name: bananas
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:
@@ -2669,6 +2697,7 @@ schemas: !<!Schemas>
         xml:
           name: SignedIdentifiers
           attribute: false
+          text: false
           wrapped: true
       language: !<!Languages> 
         default:

--- a/modelerfour/test/test-modeler.ts
+++ b/modelerfour/test/test-modeler.ts
@@ -239,17 +239,6 @@ class Process {
   async 'acceptance-suite'() {
     const folders = await readdir(`${__dirname}/../../test/scenarios/`);
     for (const each of folders) {
-      if ([
-        'body-formdata',
-        'body-formdata-urlencoded',
-      ].indexOf(each) > -1) {
-        console.log(`Skipping: ${each}`);
-        continue;
-      }
-      /* if ('body-complex' !== each) {
-        console.log(`Skipping: ${each}`);
-        continue;
-      } */
       console.log(`Processing: ${each}`);
 
       const cfg = {


### PR DESCRIPTION
This is the last step in enabling `multipart/form-data` requests to be handled by AutoRest v3 and Modelerfour.  It creates an `HttpMultipartRequest` when an operation accepts a `multipart/form-data` content type.  It basically mimics the `HttpWithBodyRequest` implementation but tweaks it slightly to specify the correct `KnownMediaType`.