### PR TITLE
Promote `x-ms-text` extension to `xml`'s `text` property

### DIFF
--- a/modelerfour/modeler/interpretations.ts
+++ b/modelerfour/modeler/interpretations.ts
@@ -21,7 +21,8 @@ const removeKnownParameters = [
   'x-ms-original',
   'x-ms-requestBody-name',
   'x-ms-requestBody-index',
-  'x-ms-api-version'
+  'x-ms-api-version',
+  'x-ms-text'
 ];
 
 // ref: https://www.w3schools.com/charsets/ref_html_ascii.asp
@@ -193,9 +194,14 @@ export class Interpretations {
 
   getXmlSerialization(schema: OpenAPI.Schema): XmlSerlializationFormat | undefined {
     if (schema.xml) {
+      if (schema.xml['x-ms-text'] && schema.xml.attribute) {
+        throw new Error(`XML serialization for a schema cannot be in both 'text' and 'attribute'`);
+      }
+
       return {
         attribute: schema.xml.attribute || false,
         wrapped: schema.xml.wrapped || false,
+        text: schema.xml['x-ms-text'] || false,
         name: schema.xml.name || undefined,
         namespace: schema.xml.namespace || undefined,
         prefix: schema.xml.prefix || undefined,

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -653,4 +653,49 @@ class Modeler {
       "Header with no client name"
     );
   }
+
+  @test
+  async "x-ms-text extension in xml object will be moved to 'text' property"() {
+    const spec = createTestSpec();
+
+    addSchema(spec, "HasOnlyText", {
+      type: "object",
+      properties: {
+        message: {
+          type: "string",
+          xml: {
+            "x-ms-text": true
+          }
+        }
+      }
+    });
+
+    const codeModel = await runModeler(spec);
+
+    assertSchema(
+      "HasOnlyText",
+      codeModel.schemas.objects,
+      o => o.properties[0].schema.serialization.xml.text,
+      true
+    );
+
+    addSchema(spec, "HasTextAndAttribute", {
+      type: "object",
+      properties: {
+        message: {
+          type: "string",
+          xml: {
+            "x-ms-text": true,
+            attribute: true
+          }
+        }
+      }
+    });
+
+    // Should throw when both 'text' and 'attribute' are true
+    await assert.rejects(
+      () => runModeler(spec),
+      /XML serialization for a schema cannot be in both 'text' and 'attribute'$/
+    );
+  }
 }


### PR DESCRIPTION
This change addresses #330 which requests that the `x-ms-text` extension on a schema property's `xml` object should be promoted to the CodeModel property `XmlSerializationFormat.text`.  This depends on a CodeModel improvement in https://github.com/Azure/perks/pull/125.  I've added a unit test to exercise both the positive and negative cases (setting both `text` and `attribute` to true throws an error).