### PR TITLE
Add 'always-seal-x-ms-enums' setting to force SealedChoiceSchema

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -499,10 +499,12 @@ export class ModelerFour {
   processChoiceSchema(name: string, schema: OpenAPI.Schema): ChoiceSchema | SealedChoiceSchema | ConstantSchema {
     const xmse = <XMSEnum>schema['x-ms-enum'];
     name = (xmse && xmse.name) || this.interpret.getName(name, schema);
-    const sealed = xmse && !(xmse.modelAsString);
+
+    const alwaysSeal = this.options[`always-seal-x-ms-enums`] === true;
+    const sealed = xmse && (alwaysSeal || !(xmse.modelAsString));
 
     // model as string forces it to be a choice/enum.
-    if (xmse?.modelAsString !== true && (length(schema.enum) === 1 || length(xmse?.values) === 1)) {
+    if (!alwaysSeal && xmse?.modelAsString !== true && (length(schema.enum) === 1 || length(xmse?.values) === 1)) {
       const constVal = length(xmse?.values) === 1 ? xmse?.values?.[0]?.value : schema?.enum?.[0];
 
       return this.codeModel.schemas.add(new ConstantSchema(name, this.interpret.getDescription(``, schema), {

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -3,6 +3,8 @@
 ## Changelog:
 #### 4.15.x
   - Schemas with `x-ms-enum`'s `modelAsString` set to `true` will now be represented as `ChoiceSchema` even with a single value.
+  - `Accept` headers are now automatically added to operations having responses with content types
+  - Added `always-seal-x-ms-enum` settings to always create `SealedChoiceSchema` when an `x-ms-enum` is encountered
 
 #### 4.14.x
   - added `exception` SchemaContext for `usage` when used as an exception response
@@ -176,6 +178,11 @@ modelerfour:
   # always create the content-type parameter for binary requests 
   # when it's only one possible value, make it a constant.
   always-create-content-type-parameter: true
+
+  # always create SealedChoiceSchema for x-ms-enum schemas no matter
+  # what the settings are.  This can be used to smooth migration from
+  # remodeler to modelerfour.
+  always-seal-x-ms-enum: false|true
 
   # customization of the identifier normalization and naming provided by the prenamer.
   # pascal|pascalcase - MultiWordIdentifier 


### PR DESCRIPTION
This change adds a new `always-seal-x-ms-enums` setting that will cause `SealedChoiceSchema` to be used any time an `x-ms-enum` extension is present on an `enum` schema.  This is intended to improve compatibility with `remodeler` to help the `autorest.powershell` team migrate to `modelerfour` (see issue #329 for more details).