### PR TITLE
Enable api-version header parameters via x-ms-api-version

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -63,12 +63,12 @@ languages:
     outputPath: ../modelerfour/test/regression/python
     oldArgs:
       - --v3
-      - --use:@autorest/python@5.1.0-preview.3
-      - --use:@autorest/modelerfour@4.15.375
+      - --use:@autorest/python@5.2.0-preview.1
+      - --use:@autorest/modelerfour@4.15.410
     newArgs:
       - --v3
       - --use:../modelerfour
-      - --use:@autorest/python@5.1.0-preview.3
+      - --use:@autorest/python@5.2.0-preview.1
   - language: typescript
     outputPath: ../modelerfour/test/regression/typescript
     excludeSpecs:
@@ -78,11 +78,11 @@ languages:
       - --v3
       - --package-name:test-package
       - --title:TestClient
-      - --use:@autorest/typescript@6.0.0-dev.20200626.1
-      - --use:@autorest/modelerfour@4.15.375
+      - --use:@autorest/typescript@6.0.0-dev.20200826.1
+      - --use:@autorest/modelerfour@4.15.410
     newArgs:
       - --v3
       - --package-name:test-package
       - --title:TestClient
       - --use:../modelerfour
-      - --use:@autorest/typescript@6.0.0-dev.20200626.1
+      - --use:@autorest/typescript@6.0.0-dev.20200826.1

--- a/modelerfour/modeler/interpretations.ts
+++ b/modelerfour/modeler/interpretations.ts
@@ -152,14 +152,15 @@ export class Interpretations {
   }
 
   isApiVersionParameter(parameter: OpenAPI.Parameter): boolean {
-    if (parameter.in !== ParameterLocation.Query) {
-      return false;
+    // Always let x-ms-api-version override the check
+    if (parameter['x-ms-api-version'] !== undefined) {
+      return !!parameter['x-ms-api-version'] === true;
     }
-    if (parameter['x-ms-api-version'] === false) {
-      return false;
-    }
-    return !!(parameter['x-ms-api-version'] === true || apiVersionParameterNames.find(each => each === parameter.name.toLowerCase()));
+
+    // It's an api-version parameter if it's a query param with an expected name
+    return parameter.in === ParameterLocation.Query && !!apiVersionParameterNames.find(each => each === parameter.name.toLowerCase());
   }
+
   getEnumChoices(schema: OpenAPI.Schema): Array<ChoiceValue> {
     if (schema && schema.enum) {
       const xmse = <XMSEnum>schema['x-ms-enum'];


### PR DESCRIPTION
This change enables header parameters to be explicitly marked as client- or method-level `api-version` parameters using the `x-ms-api-version` extension.  Issue #339 reports that this extension only works for query parameters but there is a service that requires it in header parameters.  This PR satisfies that request.