### PR TITLE
Propagate extension properties to response headers

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1577,6 +1577,7 @@ export class ModelerFour {
             const hsch = this.processSchema(this.interpret.getName(header, sch), sch);
             hsch.language.default.header = header;
             headers.push(new HttpHeader(header, hsch, {
+              extensions: this.interpret.getExtensionProperties(hh),
               language: {
                 default: {
                   name: hh['x-ms-client-name'] || header,
@@ -1608,6 +1609,7 @@ export class ModelerFour {
               const hsch = this.processSchema(this.interpret.getName(header, sch), sch);
               hsch.language.default.header = header;
               headers.push(new HttpHeader(header, hsch, {
+              extensions: this.interpret.getExtensionProperties(hh),
                 language: {
                   default: {
                     name: hh['x-ms-client-name'] || header,

--- a/modelerfour/test/scenarios/blob-storage/flattened.yaml
+++ b/modelerfour/test/scenarios/blob-storage/flattened.yaml
@@ -12786,6 +12786,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_224
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -17331,6 +17333,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_519
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -17578,6 +17582,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_559
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -18055,6 +18061,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_601
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata

--- a/modelerfour/test/scenarios/blob-storage/grouped.yaml
+++ b/modelerfour/test/scenarios/blob-storage/grouped.yaml
@@ -17714,6 +17714,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_133
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -21453,6 +21455,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_194
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -21700,6 +21704,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_651
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -22090,6 +22096,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_692
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata

--- a/modelerfour/test/scenarios/blob-storage/modeler.yaml
+++ b/modelerfour/test/scenarios/blob-storage/modeler.yaml
@@ -12760,6 +12760,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_219
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -17305,6 +17307,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_514
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -17552,6 +17556,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_554
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -18029,6 +18035,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_596
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata

--- a/modelerfour/test/scenarios/blob-storage/namer.yaml
+++ b/modelerfour/test/scenarios/blob-storage/namer.yaml
@@ -17714,6 +17714,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_3
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -21453,6 +21455,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_64
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -21700,6 +21704,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_651
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata
@@ -22090,6 +22096,8 @@ operationGroups:
                   - !<!HttpHeader> 
                     schema: *ref_692
                     header: x-ms-meta
+                    extensions:
+                      x-ms-header-collection-prefix: x-ms-meta-
                     language:
                       default:
                         name: Metadata


### PR DESCRIPTION
This change addresses #337 which reports that `x-ms-header-collection-prefix` headers are not propagated to `HttpHeader` objects in the code model.  The fix is to ensure that extension properties are carried across to the `extensions` object under `HttpHeader`.