### PR TITLE
Allow other content types in a request with multipart/form-data

### DIFF
--- a/modelerfour/src/modeler/modelerfour.ts
+++ b/modelerfour/src/modeler/modelerfour.ts
@@ -2179,13 +2179,6 @@ export class ModelerFour {
       }
       const kmtMultipart = groupedMediaTypes.get(KnownMediaType.Multipart);
       if (kmtMultipart) {
-        if (kmtCount !== 1) {
-          throw new Error(
-            `Requests with 'multipart/formdata' can not be combined in a single operation with other media types ${keys(
-              requestBody.instance.content,
-            ).toArray()} `,
-          );
-        }
         // create multipart form upload for this.
         this.processSerializedObject(KnownMediaType.Multipart, kmtMultipart, operation, requestBody);
       }


### PR DESCRIPTION
This change removes a restriction that prevents other request content types to be used when `multipart/form-data` is one of them.  After initial testing it seems that modelerfour produces the expected code model output that will enable a generator to produce operation methods for the different content types.