### PR TITLE
Allow text/plain responses with 'type: string' schemas

### DIFF
--- a/modelerfour/modeler/modelerfour.ts
+++ b/modelerfour/modeler/modelerfour.ts
@@ -1021,9 +1021,10 @@ export class ModelerFour {
               if (!fmt.schema.instance) {
                 // if we don't have a schema at all, should we infer a binary schema anyway? 
                 // dunno.
-
               }
-              if (!this.interpret.isBinarySchema(fmt.schema.instance)) {
+
+              if (!(knownMediaType === KnownMediaType.Text && fmt.schema.instance?.type === JsonType.String)
+                  && !this.interpret.isBinarySchema(fmt.schema.instance)) {
                 // bad combo, remove.
                 mediaTypeGroups.delete(knownMediaType);
                 continue;

--- a/modelerfour/test/unit/modelerfour.test.ts
+++ b/modelerfour/test/unit/modelerfour.test.ts
@@ -1145,4 +1145,40 @@ class Modeler {
       "x-ms-meta"
     );
   }
+
+  async "allows text/plain responses when schema type is 'string'"() {
+    const spec = createTestSpec();
+
+    addOperation(spec, "/text", {
+      post: {
+        operationId: "textBody",
+        description: "Responds with a plain text string.",
+        parameters: [],
+        responses: responses(
+          response(200, "text/plain", {
+            type: "string"
+          }),
+          response(201, "text/plain; charset=utf-8", {
+            type: "string"
+          }),
+        )
+      }
+    });
+
+    const codeModel = await runModeler(spec);
+
+
+    const textBody = findByName(
+      "textBody",
+      codeModel.operationGroups[0].operations
+    );
+
+    const responseNoCharset = textBody?.responses?.[0] as SchemaResponse;
+    const responseWithCharset = textBody?.responses?.[1] as SchemaResponse;
+
+    assert.strictEqual(responseNoCharset.protocol.http?.knownMediaType, "text");
+    assert.strictEqual(responseNoCharset.schema?.type, "string");
+    assert.strictEqual(responseWithCharset.protocol.http?.knownMediaType, "text");
+    assert.strictEqual(responseWithCharset.schema?.type, "string");
+  }
 }


### PR DESCRIPTION
This change addresses issue #352 which reports that a `text/plain` response with a `"type": string` schema wasn't coming through in the code model's response list.  It turns out Modelerfour has been excluding this media type, so this PR adds support for it.