### PR TITLE
Generate unique names for synthesized schemas like ContentType

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -63,12 +63,12 @@ languages:
     outputPath: ../modelerfour/test/regression/python
     oldArgs:
       - --v3
-      - --use:@autorest/python@5.2.0-preview.1
-      - --use:@autorest/modelerfour@4.15.410
+      - --use:@autorest/python@5.4.0
+      - --use:@autorest/modelerfour@4.15.421
     newArgs:
       - --v3
       - --use:../modelerfour
-      - --use:@autorest/python@5.2.0-preview.1
+      - --use:@autorest/python@5.4.0
   - language: typescript
     outputPath: ../modelerfour/test/regression/typescript
     excludeSpecs:


### PR DESCRIPTION
This change addresses an issue found by @ShivangiReja when using a newer version of the Form Recognizer spec.  When the `always-create-content-type-parameter` option is used and `image/bmp` content type is added to only one of the 3 operations that accept image types, an additional `SealedChoiceSchema` with the name `ContentType` is created, causing the "checker" phase to fail with a duplicate schema name.  This is also possible when synthesizing `Accept` headers.

The fix is to ensure uniqueness of these generated header names by adding logic to increment a numeric suffix that gets applied when more than one schema with a particular name is created.