### PR TITLE
Fix: Issue with prenamer renaming to already used values

### DIFF
--- a/modelerfour/changelog.md
+++ b/modelerfour/changelog.md
@@ -5,6 +5,7 @@
   - **Feature** Added new flag `always-create-accept-parameter` to enable/disable accept param auto generation. ([PR 366](https://github.com/Azure/autorest.modelerfour/pull/366))
   - **Fix** Allow request with body being a file and `application/json` content-type. ([PR 363](https://github.com/Azure/autorest.modelerfour/pull/363))
   - **Fix** Dictionaries of dictionaries not being modeled as such(`dict[str, object]` instead of `dict[str, dict[str, str]]`). ([PR 372](https://github.com/Azure/autorest.modelerfour/pull/372))
+  - **Fix** Issue with duplicates schemas names due to consequtive name duplicate removal. ([PR 374](https://github.com/Azure/autorest.modelerfour/pull/374))
 
 #### 4.15.x
   - Schemas with `x-ms-enum`'s `modelAsString` set to `true` will now be represented as `ChoiceSchema` even with a single value.

--- a/modelerfour/src/prenamer/naming-utils.ts
+++ b/modelerfour/src/prenamer/naming-utils.ts
@@ -21,12 +21,22 @@ export function getNameOptions(typeName: string, components: Array<string>) {
 }
 
 interface SetNameOptions {
-  removeDuplicates: boolean;
+  /**
+   * Remove consecutive duplicate words in the name.
+   * @example "FooBarBarSomething" -> "FooBarSomething"
+   */
+  removeDuplicates?: boolean;
+
+  /**
+   * Set containing the list of names already used in the given scope.
+   */
+  existingNames?: Set<string>;
 }
 
-const setNameDefaultOptions: SetNameOptions = {
+const setNameDefaultOptions: Required<SetNameOptions> = Object.freeze({
   removeDuplicates: true,
-};
+  existingNames: new Set<string>(),
+});
 
 export function setName(
   thing: { language: Languages },
@@ -50,11 +60,17 @@ export function setNameAllowEmpty(
 ) {
   options = { ...setNameDefaultOptions, ...options };
 
-  thing.language.default.name = styler(
+  const newName = styler(
     defaultValue && isUnassigned(thing.language.default.name) ? defaultValue : thing.language.default.name,
     options.removeDuplicates,
     overrides,
   );
+
+  // Check if the new name is not yet taken.
+  if (newName && !options.existingNames?.has(newName)) {
+    options.existingNames?.add(newName);
+    thing.language.default.name = newName;
+  }
 }
 
 export function isUnassigned(value: string) {

--- a/modelerfour/src/prenamer/naming-utils.ts
+++ b/modelerfour/src/prenamer/naming-utils.ts
@@ -1,0 +1,62 @@
+import { Languages } from "@azure-tools/codemodel";
+import { length, Dictionary } from "@azure-tools/linq";
+import { removeSequentialDuplicates, fixLeadingNumber, deconstruct, Style, Styler } from "@azure-tools/codegen";
+
+export function getNameOptions(typeName: string, components: Array<string>) {
+  const result = new Set<string>();
+
+  // add a variant for each incrementally inclusive parent naming scheme.
+  for (let i = 0; i < length(components); i++) {
+    const subset = Style.pascal([...removeSequentialDuplicates(components.slice(-1 * i, length(components)))]);
+    result.add(subset);
+  }
+
+  // add a second-to-last-ditch option as <typename>.<name>
+  result.add(
+    Style.pascal([
+      ...removeSequentialDuplicates([...fixLeadingNumber(deconstruct(typeName)), ...deconstruct(components.last)]),
+    ]),
+  );
+  return [...result.values()];
+}
+
+interface SetNameOptions {
+  removeDuplicates: boolean;
+}
+
+const setNameDefaultOptions: SetNameOptions = {
+  removeDuplicates: true,
+};
+
+export function setName(
+  thing: { language: Languages },
+  styler: Styler,
+  defaultValue: string,
+  overrides: Dictionary<string>,
+  options?: SetNameOptions,
+) {
+  setNameAllowEmpty(thing, styler, defaultValue, overrides, options);
+  if (!thing.language.default.name) {
+    throw new Error("Name is empty!");
+  }
+}
+
+export function setNameAllowEmpty(
+  thing: { language: Languages },
+  styler: Styler,
+  defaultValue: string,
+  overrides: Dictionary<string>,
+  options?: SetNameOptions,
+) {
+  options = { ...setNameDefaultOptions, ...options };
+
+  thing.language.default.name = styler(
+    defaultValue && isUnassigned(thing.language.default.name) ? defaultValue : thing.language.default.name,
+    options.removeDuplicates,
+    overrides,
+  );
+}
+
+export function isUnassigned(value: string) {
+  return !value || value.indexOf("·") > -1;
+}

--- a/modelerfour/src/prenamer/naming-utils.ts
+++ b/modelerfour/src/prenamer/naming-utils.ts
@@ -33,9 +33,8 @@ interface SetNameOptions {
   existingNames?: Set<string>;
 }
 
-const setNameDefaultOptions: Required<SetNameOptions> = Object.freeze({
+const setNameDefaultOptions: SetNameOptions = Object.freeze({
   removeDuplicates: true,
-  existingNames: new Set<string>(),
 });
 
 export function setName(


### PR DESCRIPTION
When a name was containing duplicate consecutive words it was removing the duplicates but the target name could have already been used. So it will only do that if it is not being used yet.

+ A little cleanup and reoganization of prenamer