### PR TITLE
Put the removal of empty child schemas behind a flag

### DIFF
--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -93,7 +93,7 @@ modelerfour:
   # In the case where a type only definition is to inherit another type remove it.
   # e.g. ChildSchema: {allOf: [ParentSchema]}. 
   # In this case ChildSchema will be removed and all reference to it will be updated to point to ParentSchema
-  remove-empty-child-types: false|true
+  remove-empty-child-schemas: false|true
 
   # customization of the identifier normalization and naming provided by the prenamer.
   # pascal|pascalcase - MultiWordIdentifier 

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -92,7 +92,7 @@ modelerfour:
 
   # In the case where there is inheritance `Model > Parent > GrandParent` and Parent is empty,
   # remove the Parent class and change the reference `Model > GrandParent`.
-  remove-unused-intermediate-parent-types: false|true
+  remove-empty-child-types: false|true
 
   # customization of the identifier normalization and naming provided by the prenamer.
   # pascal|pascalcase - MultiWordIdentifier 

--- a/modelerfour/readme.md
+++ b/modelerfour/readme.md
@@ -90,6 +90,10 @@ modelerfour:
   # remodeler to modelerfour.
   always-seal-x-ms-enum: false|true
 
+  # In the case where there is inheritance `Model > Parent > GrandParent` and Parent is empty,
+  # remove the Parent class and change the reference `Model > GrandParent`.
+  remove-unused-intermediate-parent-types: false|true
+
   # customization of the identifier normalization and naming provided by the prenamer.
   # pascal|pascalcase - MultiWordIdentifier 
   # camel|camelcase - multiWordIdentifier 

--- a/modelerfour/src/modeler/modelerfour-options.ts
+++ b/modelerfour/src/modeler/modelerfour-options.ts
@@ -33,6 +33,12 @@ export interface ModelerFourOptions {
   "prenamer"?: boolean;
 
   "resolve-schema-name-collisons"?: boolean;
+
+  /**
+   * In the case where there is inheritance `Model > Parent > GrandParent` and Parent is empty,
+   * remove the Parent class and change the reference `Model > GrandParent`.
+   */
+  "remove-unused-intermediate-parent-types"?: boolean;
 }
 
 export interface ModelerFourNamingOptions {

--- a/modelerfour/src/modeler/modelerfour-options.ts
+++ b/modelerfour/src/modeler/modelerfour-options.ts
@@ -39,7 +39,7 @@ export interface ModelerFourOptions {
    * @example ChildSchema: {allOf: [ParentSchema]}. 
    * In this case ChildSchema will be removed and all reference to it will be updated to point to ParentSchema
    */
-  "remove-empty-child-types"?: boolean;
+  "remove-empty-child-schemas"?: boolean;
 }
 
 export interface ModelerFourNamingOptions {

--- a/modelerfour/src/modeler/modelerfour-options.ts
+++ b/modelerfour/src/modeler/modelerfour-options.ts
@@ -35,10 +35,11 @@ export interface ModelerFourOptions {
   "resolve-schema-name-collisons"?: boolean;
 
   /**
-   * In the case where there is inheritance `Model > Parent > GrandParent` and Parent is empty,
-   * remove the Parent class and change the reference `Model > GrandParent`.
+   * In the case where a type only definition is to inherit another type remove it.
+   * @example ChildSchema: {allOf: [ParentSchema]}. 
+   * In this case ChildSchema will be removed and all reference to it will be updated to point to ParentSchema
    */
-  "remove-unused-intermediate-parent-types"?: boolean;
+  "remove-empty-child-types"?: boolean;
 }
 
 export interface ModelerFourNamingOptions {

--- a/modelerfour/src/quality-precheck/prechecker.ts
+++ b/modelerfour/src/quality-precheck/prechecker.ts
@@ -508,7 +508,7 @@ export class QualityPreChecker {
   }
 
   process() {
-    if (this.options["remove-empty-child-types"]) {
+    if (this.options["remove-empty-child-schemas"]) {
       this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
     }
 

--- a/modelerfour/src/quality-precheck/prechecker.ts
+++ b/modelerfour/src/quality-precheck/prechecker.ts
@@ -377,9 +377,9 @@ export class QualityPreChecker {
             this.input = JSON.parse(
               text.replace(new RegExp(`"\\#\\/components\\/schemas\\/${key}"`, "g"), `"${$ref}"`),
             );
-            const location = schema["x-ms-metadata"].originalLocations[0].replace(/^.*\//, "");
+            const location = schema["x-ms-metadata"].originalLocations?.[0]?.replace(/^.*\//, "");
+            delete this.input.components?.schemas?.[key];
             if (schema["x-internal-autorest-anonymous-schema"]) {
-              delete schemas[key];
               this.session.warning(
                 `An anonymous inline schema for property '${location.replace(
                   /-/g,
@@ -388,8 +388,6 @@ export class QualityPreChecker {
                 ["PreCheck", "AllOfWhenYouMeantRef"],
               );
             } else {
-              // NOTE: Disabled removing of non-anonymous schema for now until
-              // it has been discussed in Azure/autorest.modelerfour#278
               this.session.warning(
                 `Schema '${location}' is using an 'allOf' instead of a $ref. This creates a wasteful anonymous type when generating code.`,
                 ["PreCheck", "AllOfWhenYouMeantRef"],

--- a/modelerfour/src/quality-precheck/prechecker.ts
+++ b/modelerfour/src/quality-precheck/prechecker.ts
@@ -508,7 +508,7 @@ export class QualityPreChecker {
   }
 
   process() {
-    if (this.options["remove-unused-intermediate-parent-types"]) {
+    if (this.options["remove-empty-child-types"]) {
       this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
     }
 

--- a/modelerfour/src/quality-precheck/prechecker.ts
+++ b/modelerfour/src/quality-precheck/prechecker.ts
@@ -312,7 +312,7 @@ export class QualityPreChecker {
   }
 
   private removeDuplicateSchemas(name: string, schema1: DereferencedSchema, schema2: DereferencedSchema) {
-    const { keep: schemaToKeep, remove: schemaToRemove} = this.findSchemaToRemove(schema1, schema2);
+    const { keep: schemaToKeep, remove: schemaToRemove } = this.findSchemaToRemove(schema1, schema2);
     delete this.input.components!.schemas![schemaToRemove.key];
     const text = JSON.stringify(this.input);
     this.input = JSON.parse(
@@ -346,7 +346,7 @@ export class QualityPreChecker {
         );
       }
     }
-    
+
     this.session.verbose(
       `Schema ${name} has multiple identical declarations, reducing to just one - removing: ${schemaToRemove.key}, keeping: ${schemaToKeep.key}`,
       ["PreCheck", "ReducingSchema"],
@@ -510,7 +510,9 @@ export class QualityPreChecker {
   }
 
   process() {
-    //this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
+    if (this.options["remove-unused-intermediate-parent-types"]) {
+      this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
+    }
 
     this.fixUpObjectsWithoutType();
 

--- a/modelerfour/src/quality-precheck/prechecker.ts
+++ b/modelerfour/src/quality-precheck/prechecker.ts
@@ -510,7 +510,7 @@ export class QualityPreChecker {
   }
 
   process() {
-    this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
+    //this.fixUpSchemasThatUseAllOfInsteadOfJustRef();
 
     this.fixUpObjectsWithoutType();
 

--- a/modelerfour/test/quality-precheck/prechecker.test.ts
+++ b/modelerfour/test/quality-precheck/prechecker.test.ts
@@ -120,7 +120,7 @@ describe("Prechecker", () => {
 
     it("Remove the child type and points reference to it to its parent", async () => {
       const client = await PreCheckerClient.create(spec, {
-        "remove-empty-child-types": true,
+        "remove-empty-child-schemas": true,
       });
       const schemas = client.result.components!.schemas!;
       expect(schemas["ChildSchema"]).toBeUndefined();

--- a/modelerfour/test/quality-precheck/prechecker.test.ts
+++ b/modelerfour/test/quality-precheck/prechecker.test.ts
@@ -120,7 +120,7 @@ describe("Prechecker", () => {
 
     it("Remove the child type and points reference to it to its parent", async () => {
       const client = await PreCheckerClient.create(spec, {
-        "remove-unused-intermediate-parent-types": true,
+        "remove-empty-child-types": true,
       });
       const schemas = client.result.components!.schemas!;
       expect(schemas["ChildSchema"]).toBeUndefined();


### PR DESCRIPTION
This pr is a follow up of this one https://github.com/Azure/autorest.modelerfour/pull/274. It seems like part of the behavior was already disabled in that PR(Removing the model but it was still referenced)

This PR puts the entire step behind a new flag `remove-empty-child-types` which is disabled by default. With that change it also revert the change from pr #274 to not delete the child schema. As this is now only applicable when the flag is set this felt like it was good to reintroduce the original behavior
fix Azure/autorest#3635
fix Azure/autorest#3650

From what I understand from pr #274, the original behavior(removing empty child schemas) was designed to prevent having a multitude of meaningless schemas. This however prevent some uses cases which I think the 2 issues this solve where using:
- Having a different class name for the child to leave room for additions without breaking changes at a later point.
- Just having a different name for the schema.

I am not sure we should even have this behavior at all. From what I understand there is 2 ways which have different purpose:
- `allOf` with a single `$ref` -> This correspond to having a `ChildModel` extending a `ParentModel` without anything else.
- just a `$ref` -> this correspond to making a copy of the ParentSchema. (And so they would totally unrelated classes in a language not doing pattern matching)